### PR TITLE
Force load slides when navigating past them with lazy loading

### DIFF
--- a/src/components/panels/helpers/toc-item.vue
+++ b/src/components/panels/helpers/toc-item.vue
@@ -118,10 +118,16 @@ const props = defineProps({
     }
 });
 
+const emit = defineEmits(['scroll-to-slide']);
+
 const scrollToChapter = (id: string): void => {
     const el = document.getElementById(id);
     if (el) {
-        el.scrollIntoView({ behavior: 'smooth' });
+        // Delay is needed to allow slides to force load when lazy loading is enabled
+        emit('scroll-to-slide', props.tocItem.slideIndex);
+        setTimeout(() => {
+            el.scrollIntoView({ behavior: 'smooth' });
+        }, 100);
     }
 };
 

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, ref, onMounted, getCurrentInstance } from 'vue';
+import { getCurrentInstance, onMounted, onUpdated, reactive, ref } from 'vue';
 import type { PropType } from 'vue';
 import type { ImagePanel, ConfigFileStructure } from '@storylines/definitions';
 
@@ -45,6 +45,9 @@ const props = defineProps({
     },
     lazyLoad: {
         type: Boolean
+    },
+    forceLoad: {
+        type: Boolean
     }
 });
 
@@ -55,17 +58,33 @@ const state = reactive({
 });
 
 const observer = ref<IntersectionObserver | undefined>(undefined);
+const loaded = ref<Boolean>(false);
+
+onUpdated(() => {
+    // Only needs to occur once.
+    if (!loaded.value && props.forceLoad) {
+        (img.value as Element).setAttribute('src', props.config.src);
+        getCurrentInstance()?.proxy?.$forceUpdate();
+        loaded.value = true;
+    }
+});
 
 onMounted((): void => {
     state.src = props.config.src ? props.config.src : '';
+    loaded.value = !props.lazyLoad; // if lazy loading is enabled, the image content will initially not be loaded
 
     if (props.lazyLoad && props.slideIdx > 2) {
         observer.value = new IntersectionObserver(([image]) => {
+            // dont want video to be loaded a second time if it was force loaded already
+            if (loaded.value) {
+                (observer.value as IntersectionObserver).disconnect();
+            }
             // lazy load images
-            if (image.isIntersecting) {
+            else if (image.isIntersecting) {
                 (img.value as Element).setAttribute('src', props.config.src);
                 getCurrentInstance()?.proxy?.$forceUpdate();
                 (observer.value as IntersectionObserver).disconnect();
+                loaded.value = true;
             }
         });
     }

--- a/src/components/panels/interactive-image-panel.vue
+++ b/src/components/panels/interactive-image-panel.vue
@@ -88,7 +88,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
-import { defineAsyncComponent, getCurrentInstance, onMounted, ref } from 'vue';
+import { defineAsyncComponent, getCurrentInstance, onMounted, onUpdated, ref } from 'vue';
 import type {
     BasePanel,
     ConfigFileStructure,
@@ -115,6 +115,9 @@ const props = defineProps({
     },
     lazyLoad: {
         type: Boolean
+    },
+    forceLoad: {
+        type: Boolean
     }
 });
 
@@ -138,15 +141,30 @@ const isMobile = ref(false);
 const key = getCurrentInstance()?.vnode.key as string;
 
 const observer = ref<IntersectionObserver | undefined>(undefined);
+const loaded = ref<Boolean>(false);
+
+onUpdated(() => {
+    if (!loaded.value && props.forceLoad) {
+        activeImage.value = currentDefaultImage.value;
+        getCurrentInstance()?.proxy?.$forceUpdate();
+        loaded.value = true;
+    }
+});
 
 onMounted(() => {
+    loaded.value = !props.lazyLoad; // if lazy loading is enabled, the image content will initially not be loaded
     if (props.lazyLoad && props.slideIdx && props.slideIdx > 2) {
         observer.value = new IntersectionObserver(([image]) => {
+            // dont want image to be loaded a second time if it was force loaded already
+            if (loaded.value) {
+                (observer.value as IntersectionObserver).disconnect();
+            }
             // lazy load images
-            if (image.isIntersecting) {
+            else if (image.isIntersecting) {
                 activeImage.value = currentDefaultImage.value;
                 getCurrentInstance()?.proxy?.$forceUpdate();
                 (observer.value as IntersectionObserver).disconnect();
+                loaded.value = true;
             }
         });
     }

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -19,6 +19,7 @@
             :class="config.cssClasses"
             :isSlideshowItem="isSlideshowItem"
             :lazyLoad="lazyLoad"
+            :forceLoad="forceLoad"
             :background="background"
         ></component>
     </div>
@@ -61,6 +62,9 @@ const props = defineProps({
         type: Boolean
     },
     lazyLoad: {
+        type: Boolean
+    },
+    forceLoad: {
         type: Boolean
     },
     isSlideshowItem: {

--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -152,7 +152,7 @@
                         'is-active': lastActiveIdx === item.slideIndex || isSublistActive(item.sublist)
                     }"
                 >
-                    <toc-item :tocItem="item" :slides="slides" :plugin="plugin">
+                    <toc-item :tocItem="item" :slides="slides" :plugin="plugin" @scroll-to-slide="scrollToTarget">
                         <button
                             class="mr-1"
                             :aria-label="$t('chapters.menu.dropdown')"
@@ -214,6 +214,7 @@
                         :tocItem="{ ...slide, slideIndex: slide.index }"
                         :slides="slides"
                         :plugin="plugin"
+                        @scroll-to-slide="scrollToTarget"
                     ></toc-item>
                 </li>
             </template>
@@ -261,6 +262,8 @@ const lastActiveIdx = ref(-1);
 
 const sublistToggled = ref({} as Record<number, boolean>);
 
+const emit = defineEmits(['scroll-to-slide']);
+
 // filter out which slides are visible in the table of contents while preserving original slide index
 const tocSlides = computed(() => {
     let slides = props.slides.map((slide, idx) => ({ ...slide, index: idx }));
@@ -269,6 +272,10 @@ const tocSlides = computed(() => {
     }
     return slides;
 });
+
+const scrollToTarget = (index) => {
+    emit('scroll-to-slide', index);
+};
 
 const customTocSlides = computed(() => {
     if (props.customToc) {

--- a/src/components/story/horizontal-menu.vue
+++ b/src/components/story/horizontal-menu.vue
@@ -50,7 +50,13 @@
                     ref="itemContainer"
                     @focusout="handleFocus(idx)"
                 >
-                    <toc-item :tocItem="item" :slides="slides" :verticalToc="false" :plugin="plugin">
+                    <toc-item
+                        :tocItem="item"
+                        :slides="slides"
+                        :verticalToc="false"
+                        :plugin="plugin"
+                        @scroll-to-slide="scrollToTarget"
+                    >
                         <button
                             class="mr-1"
                             :aria-label="$t('chapters.menu.dropdown')"
@@ -89,6 +95,7 @@
                                 :parentItem="false"
                                 :verticalToc="false"
                                 :plugin="plugin"
+                                @scroll-to-slide="scrollToTarget"
                             ></toc-item>
                         </li>
                     </ul>
@@ -110,6 +117,7 @@
                         :slides="slides"
                         :verticalToc="false"
                         :plugin="plugin"
+                        @scroll-to-slide="scrollToTarget"
                     ></toc-item>
                 </li>
             </template>
@@ -155,6 +163,8 @@ const lastActiveIdx = ref(-1);
 
 const sublistToggled = ref<number>(-1);
 const itemContainer = ref(null);
+
+const emit = defineEmits(['scroll-to-slide']);
 
 // filter out which slides are visible in the table of contents while preserving original slide index
 const tocSlides = computed(() => {
@@ -212,6 +222,10 @@ const handleMouseClick = (event: MouseEvent): void => {
     } else {
         hideSublists();
     }
+};
+
+const scrollToTarget = (index) => {
+    emit('scroll-to-slide', index);
 };
 
 const scrollToChapter = (id: string): void => {

--- a/src/components/story/mobile-menu.vue
+++ b/src/components/story/mobile-menu.vue
@@ -129,7 +129,7 @@
                         'is-active': lastActiveIdx === item.slideIndex || isSublistActive(item.sublist)
                     }"
                 >
-                    <toc-item :tocItem="item" :slides="slides" :plugin="plugin">
+                    <toc-item :tocItem="item" :slides="slides" :plugin="plugin" @scroll-to-slide="scrollToTarget">
                         <button
                             class="mr-1"
                             :aria-label="$t('chapters.menu.dropdown')"
@@ -174,6 +174,7 @@
                                 :slides="slides"
                                 :parentItem="false"
                                 :plugin="plugin"
+                                @scroll-to-slide="scrollToTarget"
                             ></toc-item>
                         </li>
                     </ul>
@@ -186,7 +187,12 @@
                     :key="idx"
                     :class="{ 'is-active': lastActiveIdx === slide.index }"
                 >
-                    <toc-item :tocItem="{ ...slide, slideIndex: slide.index }" :slides="slides" :plugin="plugin"></toc-item>
+                    <toc-item
+                        :tocItem="{ ...slide, slideIndex: slide.index }"
+                        :slides="slides"
+                        :plugin="plugin"
+                        @scroll-to-slide="scrollToTarget"
+                    ></toc-item>
                 </li>
             </template>
         </ul>
@@ -231,6 +237,8 @@ const lastActiveIdx = ref(-1);
 
 const sublistToggled = ref({} as Record<number, boolean>);
 
+const emit = defineEmits(['scroll-to-slide']);
+
 // filter out which slides are visible in the table of contents while preserving original slide index
 const tocSlides = computed(() => {
     let slides = props.slides.map((slide, idx) => ({ ...slide, index: idx }));
@@ -274,6 +282,10 @@ onMounted(() => {
     }
 });
 
+const scrollToTarget = (index) => {
+    emit('scroll-to-slide', index);
+};
+
 const scrollToChapter = (id: string): void => {
     const el = document.getElementById(id);
     if (el) {
@@ -291,14 +303,16 @@ const isSublistToggled = (index: number): boolean => {
 
 const isSublistActive = (sublist: MenuItem[] | undefined): boolean => {
     if (sublist) {
-        return sublist.some(subItem => lastActiveIdx.value === subItem.slideIndex);
+        return sublist.some((subItem) => lastActiveIdx.value === subItem.slideIndex);
     }
     return false;
 };
 
 const updateActiveIdx = () => {
     if (props.customToc) {
-        const prevCustomSlides: MenuItem[] = customTocSlides.value!.filter((slide) => slide.slideIndex <= props.activeChapterIndex);
+        const prevCustomSlides: MenuItem[] = customTocSlides.value!.filter(
+            (slide) => slide.slideIndex <= props.activeChapterIndex
+        );
         lastActiveIdx.value = prevCustomSlides.length ? prevCustomSlides[prevCustomSlides.length - 1].slideIndex : -1;
     } else {
         const prevSlides = tocSlides.value.filter((slide) => slide.index <= props.activeChapterIndex);

--- a/src/components/story/slide.vue
+++ b/src/components/story/slide.vue
@@ -14,6 +14,7 @@
             :ratio="defaultRatio"
             :slideIdx="slideIdx"
             :lazyLoad="lazyLoad"
+            :forceLoad="forceLoad"
             :lang="lang"
             :class="determinePanelOrder(idx)"
             :background="!!config.backgroundImage && background"
@@ -48,6 +49,9 @@ const props = defineProps({
         type: Boolean
     },
     lazyLoad: {
+        type: Boolean
+    },
+    forceLoad: {
         type: Boolean
     }
 });

--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -12,6 +12,7 @@
             :plugin="!!configFileStructure || !!plugin"
             :lang="lang"
             :style="{ top: headerHeight + 'px' }"
+            @scroll-to-slide="setTargetIndex"
             v-if="$props.config?.tocOrientation === 'horizontal'"
         />
         <chapter-menu
@@ -22,6 +23,7 @@
             :customToc="config.tableOfContents"
             :plugin="!!configFileStructure || !!plugin"
             :lang="lang"
+            @scroll-to-slide="setTargetIndex"
             v-else
         />
 
@@ -48,6 +50,7 @@
                         :configFileStructure="configFileStructure"
                         :class="addPanelPadding(idx)"
                         :slideIdx="idx"
+                        :forceLoad="config.lazyLoad && slideInRange(idx)"
                         :lang="lang"
                         :background="hasBackground"
                         :lazyLoad="config.lazyLoad ?? true"
@@ -61,7 +64,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
-import { onMounted, ref } from 'vue';
+import { onMounted, onUpdated, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { ConfigFileStructure, Slide, StoryRampConfig } from '@storylines/definitions';
 import 'intersection-observer';
@@ -92,6 +95,10 @@ const props = defineProps({
     },
     headerHeight: {
         type: Number
+    },
+    targetIndex: {
+        type: Number,
+        required: false
     }
 });
 
@@ -101,8 +108,22 @@ const backgroundImage = ref<string>('none');
 const backgroundImageAlt = ref<string>('');
 const hasBackground = ref<boolean>(false); // different from above; this considers animation time
 const backgroundCss = ref<string>('');
+const targetIndex = ref(-1);
+
+onUpdated(() => {
+    // Needed for mobile toc, as well as when a slide id is manually inserted in the url. The change made to
+    // `targetIndex` here will result in slideInRange() being called for each slide component
+    if (props.targetIndex) {
+        targetIndex.value = props.targetIndex;
+    }
+});
 
 onMounted(() => {
+    // Needed for mobile toc. The change made to `targetIndex` here will result in slideInRange() being called
+    // for each slide component
+    if (props.targetIndex) {
+        targetIndex.value = props.targetIndex;
+    }
     const hash = route?.hash.substring(1);
     if (hash) {
         // Wait for a short period of time and then jump to the anchor.
@@ -124,6 +145,20 @@ onMounted(() => {
     // as you scroll down.
     handleSlideChange(0);
 });
+
+// Determines whether the slide corresponding to the provided index
+const slideInRange = (index) => {
+    return (
+        (index <= activeChapterIndex.value && index >= targetIndex.value) ||
+        (index >= activeChapterIndex.value && index <= targetIndex.value)
+    );
+};
+
+const setTargetIndex = (index) => {
+    // For every slide whose index is between `activeChapterIndex` and `index`, we must ensure that any image/video slides
+    // are force loaded. Ensure that this only happens if lazy loading is enabled. Otherwise do nothing
+    targetIndex.value = index;
+};
 
 const handleSlideChange = (event: number): void => {
     const img = (props.config.slides[event] as Slide).backgroundImage;

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -28,6 +28,7 @@
                         :return-to-top="config.returnTop ?? true"
                         :customToc="config.tableOfContents"
                         :slides="config.slides"
+                        @scroll-to-slide="setTargetIndex"
                         :lang="lang"
                     />
                     <div class="flex-none w-mobile-full truncate">
@@ -53,7 +54,13 @@
             <intro :config="config.introSlide"></intro>
 
             <div class="w-full mx-auto pb-10 mb-6" id="story">
-                <story-content :config="config" :lang="lang" :headerHeight="headerHeight" @step="updateActiveIndex" />
+                <story-content
+                    :config="config"
+                    :lang="lang"
+                    :headerHeight="headerHeight"
+                    @step="updateActiveIndex"
+                    :targetIndex="targetIndex"
+                />
             </div>
 
             <footer class="p-8 pt-2 text-right text-sm">
@@ -76,7 +83,7 @@
 </template>
 
 <script setup lang="ts">
-import { getCurrentInstance, onMounted, ref } from 'vue';
+import { getCurrentInstance, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useRoute, type RouteLocationNormalized } from 'vue-router';
 
 import MobileMenu from './mobile-menu.vue';
@@ -85,16 +92,21 @@ import Intro from '@storylines/components/story/introduction.vue';
 
 import type { StoryRampConfig } from '@storylines/definitions';
 import { VueSpinnerOval } from 'vue3-spinners';
+import { EventBus } from '../../event-bus';
 
 const route = useRoute();
 
 const config = ref<StoryRampConfig | undefined>(undefined);
 const loadStatus = ref('loading');
 const activeChapterIndex = ref(-1);
+const targetIndex = ref(-1);
 const headerHeight = ref(0);
 const lang = ref('en');
 
 onMounted(() => {
+    EventBus.on('scroll-to-slide', (params) => {
+        setTargetIndex(+params.slideIndex);
+    });
     const uid = route.params.uid as string;
     lang.value = (route.params.lang as string) ? (route.params.lang as string) : 'en';
     if (uid) {
@@ -114,6 +126,12 @@ onMounted(() => {
     }
 });
 
+onBeforeUnmount(() => {
+    EventBus.off('scroll-to-slide', (params) => {
+        setTargetIndex(+params.slideIndex);
+    });
+});
+
 // react to param changes in URL
 // eslint-disable-next-line
 const beforeRouteUpdate = (to: RouteLocationNormalized, from: RouteLocationNormalized, next: () => void): void => {
@@ -125,6 +143,10 @@ const beforeRouteUpdate = (to: RouteLocationNormalized, from: RouteLocationNorma
     }
     fetchConfig(uid, lang.value);
     next();
+};
+
+const setTargetIndex = (index: number) => {
+    targetIndex.value = index;
 };
 
 /**

--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -1,2 +1,21 @@
-import Vue from 'vue';
-export const EventBus = new Vue();
+import { reactive } from 'vue';
+export const EventBus = reactive({
+    events: {},
+    emit(event, ...args) {
+        if (this.events[event]) {
+            this.events[event].forEach((callback) => callback(...args));
+        }
+    },
+    on(event, callback) {
+        if (!this.events[event]) {
+            this.events[event] = [];
+        }
+
+        this.events[event].push(callback);
+    },
+    off(event, callback) {
+        if (this.events[event]) {
+            this.events[event] = this.events[event].filter((cb) => cb !== callback);
+        }
+    }
+});

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,6 @@
 //import StoryV from '@storylines/components/story/story.vue';
 import { createRouter, createWebHashHistory, type RouteLocationNormalized } from 'vue-router';
-
+import { EventBus } from '../event-bus';
 const routes = [
     {
         path: '/',
@@ -20,15 +20,23 @@ const router = createRouter({
     routes: routes,
     // mode: 'history', // TODO: uncomment to change to history mode for nicer URLs (eliminating middle hash) see #100
     history: createWebHashHistory(),
-    scrollBehavior: function (to: RouteLocationNormalized) {
+    scrollBehavior: function (to: RouteLocationNormalized, from) {
         if (to.hash) {
-            return {
-                el: decodeURIComponent(to.hash),
-                behavior: 'smooth',
-                top:
-                    (document.getElementById('h-navbar')?.clientHeight || 0) +
-                    (document.getElementById('story-header')?.clientHeight || 0)
-            };
+            EventBus.emit('scroll-to-slide', { slideIndex: to.hash.split('-')[0].split('#').at(-1) });
+
+            // Delay is needed to allow slides to force load when lazy loading is enabled
+            const delay = from.href ? 100 : 1000; // routing upon a page reload needs more time
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    resolve({
+                        el: decodeURIComponent(to.hash),
+                        behavior: 'smooth',
+                        top:
+                            (document.getElementById('h-navbar')?.clientHeight || 0) +
+                            (document.getElementById('story-header')?.clientHeight || 0)
+                    });
+                }, delay);
+            });
         }
     }
 });


### PR DESCRIPTION
### Related Item(s)
#553

### Changes
- When lazy loading is enabled, slides will be force loaded whenever they are navigated past during a route navigation resulting from clicking a ToC item
- Created a 100ms delay for routing, so that the images/videos have enough time to force load in before they are navigated past

### Notes
- Added some comments to help out with tested. Should be removed prior to merging

### Testing
Steps:
1. Load in a large product with images and video
2. Ensure lazy loading is enabled
3. Click on the ToC item corresponding to a slide towards the end
4. Ensure that the slide is navigated to correctly, and that the ToC item you clicked has a blue highlight
5. Ensure this works for horizontal, vertical and mobile ToC's
6. Ensure there are no issues when lazy loading in disabled

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/555)
<!-- Reviewable:end -->
