### PR TITLE
Resize interactive map and slideshow panels upon expanding ToC, Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# RAMP Storylines (formerly StoryRAMP)
+# Storylines (formerly StoryRAMP)
 
-This project is an implementation of [RAMP2 FGP Visualiser](https://github.com/fgpv-vpgf/fgpv-vpgf), [Highcharts](https://www.highcharts.com/), and a number of other libraries, with the goal to provide a standards and guidelines compliant alternative to ArcGIS StoryMap, suitable for use in the Government of Canada's web presence.
+Storylines is a storytelling platform developed in Vue 3. Interactive mapping, multimedia, charting, and many more features can be quickly and easily assembled into an attractive web application with no coding or design experience required. This framework is developed and maintained by the Web Mapping Team at Environment and Climate Change Canada.
+
+This project is an implementation of [RAMP4 (the Reusable Accessible Mapping Platform)](https://github.com/ramp4-pcar4/ramp4-pcar4), [Highcharts](https://www.highcharts.com/), and a number of other libraries, with a goal of providing a standards- and guidelines-compliant alternative to existing COTS products, suitable for use in the Government of Canada's web presence.
+
+Storylines' source code is provided free and without warranty. For inquiries, please contact [applicationsdecartographieweb-webmappingapplications@ec.gc.ca](mailto:applicationsdecartographieweb-webmappingapplications@ec.gc.ca).
 
 ## Plugin Usage
 
@@ -65,13 +69,13 @@ updateActiveIndex(idx: number): void {
 
 ```
 
-Here is a [demo](https://ramp4-pcar4.github.io/storylines/main/#/en/00000000-0000-0000-0000-000000000000) of what a Storylines product would look like.
+A wide-ranging [demo](https://ramp4-pcar4.github.io/storylines/main/#/en/00000000-0000-0000-0000-000000000000) Storylines features is available.
 
 **5. Creating Storylines config:**
 
-To create a Storylines config from scratch, please refer to the schema documnentation provided [here](https://github.com/ramp4-pcar4/storylines/blob/main/StoryRampSchema.json). A demo config can be found [here](https://github.com/ramp4-pcar4/storylines/blob/main/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json).
+To create a Storylines config from scratch, please refer to the schema documnentation provided [here](https://github.com/ramp4-pcar4/storylines/blob/main/StorylinesSchema.json). A demo config can be found [here](https://github.com/ramp4-pcar4/storylines/blob/main/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json).
 
-Alternatively, the [storylines editor](https://github.com/ramp4-pcar4/storylines-editor) can be leveraged to help construct a complete configuration folder.
+Alternatively, R.E.S.P.E.C.T. (RAMP-Enhanced Storylines Product Editor & Creation Tool), AKA the [Storylines Editor](https://github.com/ramp4-pcar4/storylines-editor) can be leveraged to help construct a complete configuration folder.
 
 ## Project setup
 
@@ -103,11 +107,13 @@ See [Configuration Reference](https://cli.vuejs.org/config/).
 
 ## Live examples
 
-- [NPRI Sector Overview: Oil Sands Extraction](https://environmental-maps.canada.ca/RAMP-Storylines/index-ca-en.html#/en/410b88da-0ed1-4749-903f-5e76c24e2e5f)
-- [NPRI Sector Overview: Pulp and Paper](https://environmental-maps.canada.ca/RAMP-Storylines/index-ca-en.html#/en/f6f7baf4-cccb-4521-a037-b4691b0f0d49)
-- [NPRI Substance Overview: Ethylene Glycol](https://environmental-maps.canada.ca/RAMP-Storylines/index-ca-en.html#/en/ea24000c-7dc3-49a9-baac-c55d28dcaeb9)
+- [Priority Places for Species at Risk](https://environmental-maps.canada.ca/CWS_Storylines/index-ca-en.html#/en/priority_places-lieux_prioritaires)
+- [Salish Sea Marine Bird Monitoring & Conservation Program](https://environmental-maps.qa.ec.gc.ca/Storylines-Scenarios/index-ca-en.html#/en/wings_over_water-ailes_audessus_de_leau)
+- [Terrestrial Cumulative Effects Initiative](https://environmental-maps.canada.ca/Storylines-Scenarios/index-ca-en.html#/en/TCEI-IECT)
 
-## Future goals
+## Related products
 
-- [ ] use [RAMP4](https://github.com/ramp4-pcar4/ramp4-pcar4) mapping platform
-- [ ] development of a web-based editor
+- [RAMP4 - Reusable Accessible Mapping Platform v4](https://github.com/ramp4-pcar4/ramp4-pcar4)
+- [RAMP4 Configuration Editor](https://github.com/ramp4-pcar4/config-editor)
+- [RESPECT - RAMP-Enhanced Storylines Product Editor & Creation Tool](https://github.com/ramp4-pcar4/storylines-editor)
+- [Highcharts Editor](https://github.com/ramp4-pcar4/highcharts-editor)

--- a/src/components/panels/interactive-map.vue
+++ b/src/components/panels/interactive-map.vue
@@ -221,7 +221,7 @@ const returnHome = async (layersToHide?: string[]) => {
 .overlap-container {
     /* when the POIs overlay the map, have the panels appear to the right */
     :deep(.panel-stack) {
-        width: 75vw;
+        width: 75%;
         justify-self: right;
     }
 
@@ -243,7 +243,7 @@ const returnHome = async (layersToHide?: string[]) => {
         height: calc(100vh - 4rem) !important;
     }
     .interactive-container {
-        grid-template-columns: repeat(1, calc(100vw - 4.1rem));
+        grid-template-columns: repeat(1, calc(100% - 5px));
     }
 }
 
@@ -281,7 +281,7 @@ const returnHome = async (layersToHide?: string[]) => {
     /* when the POIs overlay the map, have the panels appear to the right */
     .overlap-container {
         :deep(.panel-stack) {
-            width: 60vw;
+            width: 60%;
             justify-self: right;
         }
     }

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -4,7 +4,7 @@
             <div
                 ref="slideshow"
                 class="carousel-container self-center px-10 mx-auto bg-gray-200_"
-                :style="{ width: `${width}px` }"
+                :style="{ width: '100%' }"
             >
                 <carousel
                     ref="carousel"

--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -210,7 +210,11 @@
                     :key="idx"
                     :class="{ 'is-active': lastActiveIdx === slide.index }"
                 >
-                    <toc-item :tocItem="{ ...slide, slideIndex: slide.index }" :slides="slides" :plugin="plugin"></toc-item>
+                    <toc-item
+                        :tocItem="{ ...slide, slideIndex: slide.index }"
+                        :slides="slides"
+                        :plugin="plugin"
+                    ></toc-item>
                 </li>
             </template>
             <div class="h-10 flex-shrink-0"></div>
@@ -316,14 +320,16 @@ const isSublistToggled = (index: number): boolean => {
 
 const isSublistActive = (sublist: MenuItem[] | undefined): boolean => {
     if (sublist) {
-        return sublist.some(subItem => lastActiveIdx.value === subItem.slideIndex);
+        return sublist.some((subItem) => lastActiveIdx.value === subItem.slideIndex);
     }
     return false;
 };
 
 const updateActiveIdx = () => {
     if (props.customToc) {
-        const prevCustomSlides: MenuItem[] = customTocSlides.value!.filter((slide) => slide.slideIndex <= props.activeChapterIndex);
+        const prevCustomSlides: MenuItem[] = customTocSlides.value!.filter(
+            (slide) => slide.slideIndex <= props.activeChapterIndex
+        );
         lastActiveIdx.value = prevCustomSlides.length ? prevCustomSlides[prevCustomSlides.length - 1].slideIndex : -1;
     } else {
         const prevSlides = tocSlides.value.filter((slide) => slide.index <= props.activeChapterIndex);

--- a/src/components/story/horizontal-menu.vue
+++ b/src/components/story/horizontal-menu.vue
@@ -227,14 +227,16 @@ const toggleSublist = (index: number): void => {
 
 const isSublistActive = (sublist: MenuItem[] | undefined): boolean => {
     if (sublist) {
-        return sublist.some(subItem => lastActiveIdx.value === subItem.slideIndex);
+        return sublist.some((subItem) => lastActiveIdx.value === subItem.slideIndex);
     }
     return false;
 };
 
 const updateActiveIdx = () => {
     if (props.customToc) {
-        const prevCustomSlides: MenuItem[] = customTocSlides.value!.filter((slide) => slide.slideIndex <= props.activeChapterIndex);
+        const prevCustomSlides: MenuItem[] = customTocSlides.value!.filter(
+            (slide) => slide.slideIndex <= props.activeChapterIndex
+        );
         lastActiveIdx.value = prevCustomSlides.length ? prevCustomSlides[prevCustomSlides.length - 1].slideIndex : -1;
     } else {
         const prevSlides = tocSlides.value.filter((slide) => slide.index <= props.activeChapterIndex);


### PR DESCRIPTION
### Related Item(s)
#558

### Changes
- Upon opening/closing a vertical ToC, interactive map panels and slideshow panels will have their width resized accordingly
- Updated README

### Notes
- ~~After implementing this fix, I noticed that when the vertical ToC is expanded at smaller screen widths (1200px or below), there is some white space to the right of the document, which gets larger as the width is decreased~~
- ~~I had some trouble identifying where this was coming from.~~
- ~~Perhaps some element is overflowing the document? Maybe the window has a min width set somewhere?~~
- ~~I can open a new issue and look deeper into this once this PR is merged~~

### Testing
Steps:
1. Open 000... product
2. Scroll down to slides
3. Expand vertical ToC
4. Notice there is no horizontal scrollbar
5. Click a ToC item, and notice that the corresponding slide is scrolled to, without the ToC collapsing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/559)
<!-- Reviewable:end -->
