### PR TITLE
prevent slideshow panels from vertically resizing

### DIFF
--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -14,18 +14,23 @@
                     :mouseDrag="false"
                     :touchDrag="false"
                 >
-                    <slide v-for="(panelConfig, index) in config.items" :key="index" :index="index">
+                    <slide
+                        v-for="(panelConfig, index) in config.items"
+                        :key="index"
+                        :index="index"
+                        :class="{
+                            'map-carousel-item': panelConfig.type === 'map',
+                            'carousel-item': panelConfig.type !== 'map'
+                        }"
+                    >
                         <template #default="{ isActive }">
                             <panel
                                 :config="panelConfig"
                                 :configFileStructure="configFileStructure"
                                 :slideIdx="slideIdx"
                                 :isSlideshowItem="true"
-                                :class="{
-                                    'map-carousel-item': panelConfig.type === 'map',
-                                    'carousel-item': panelConfig.type !== 'map',
-                                    hidden: !isActive
-                                }"
+                                class="h-full"
+                                :class="!isActive ? 'invisible' : 'visible'"
                             ></panel>
                         </template>
                     </slide>
@@ -63,7 +68,7 @@
 <script setup lang="ts">
 import type { PropType } from 'vue';
 import { ref, onMounted } from 'vue';
-import { ConfigFileStructure, SlideshowPanel } from '@storylines/definitions';
+import type { ConfigFileStructure, SlideshowPanel } from '@storylines/definitions';
 import { Carousel, Navigation, Pagination, Slide } from 'vue3-carousel';
 import 'vue3-carousel/dist/carousel.css';
 
@@ -119,7 +124,7 @@ window.addEventListener('resize', () => {
     height: calc(100vh - 4rem - 2rem);
 }
 .carousel {
-    height: auto;
+    align-items: center;
     text-align: left;
 
     :deep(.carousel__prev > svg),
@@ -191,7 +196,6 @@ window.addEventListener('resize', () => {
 .carousel-item {
     // Max height of the carousel is 80vh, but set height to 100% so items appear in the center of the container.
     align-self: center;
-    max-height: 80vh;
     top: 0px;
     overflow-y: auto;
 }


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines-editor/issues/592

### Changes
- Removes the `hidden` class from slides, which was impeding the slideshow component from calculating the correct height.
- Replaced `hidden` with `visible`/`invisible` depending on whether the slide is active or not. This will ensure only the active slide is focusable, but retains the height of the inactive slides.

### Notes
I tested this using both the `000` and `TCEI` products pretty thoroughly, but please test this as well. The slideshow component loves to break in weird places whenever we make a styling change to it.

### Testing
Steps:
1. Open the demo page.
2. Play around with the slideshows in the product and ensure they're still working as intended. Also ensure that the slideshow height isn't changing as you change slides.