### PR TITLE
make items in plugin-mode ToC focusable by keyboard

### DIFF
--- a/src/components/panels/helpers/toc-item.vue
+++ b/src/components/panels/helpers/toc-item.vue
@@ -1,10 +1,12 @@
 <template>
     <div class="toc-item" :class="{ flex: parentItem }">
         <!-- using router-link causes a page refresh which breaks plugin -->
-        <a
+        <span
             class="flex items-center px-2 py-1 mx-1 cursor-pointer"
             :class="{ 'flex-grow pb-2 min-w-0': parentItem, 'pb-2': parentItem && !verticalToc }"
             @click="scrollToChapter(getSlideId(tocItem.slideIndex))"
+            @keydown.enter="scrollToChapter(getSlideId(tocItem.slideIndex))"
+            tabindex="0"
             v-tippy="{
                 delay: '200',
                 placement: verticalToc || !parentItem ? 'right' : 'top',
@@ -34,7 +36,7 @@
                 :class="{ 'ml-4': verticalToc && parentItem, 'pl-8': verticalToc && !parentItem }"
                 >{{ getTitle(tocItem) }}</span
             >
-        </a>
+        </span>
 
         <router-link
             :to="{ hash: `#${getSlideId(tocItem.slideIndex)}` }"

--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -37,9 +37,10 @@
 
         <ul class="nav-content menu">
             <li v-if="introExists && returnToTop">
-                <a
+                <span
                     class="flex items-center px-2 py-1 mx-1 cursor-pointer"
                     @click="scrollToChapter('intro')"
+                    @keydown.enter="scrollToChapter('intro')"
                     v-tippy="{
                         delay: '200',
                         placement: 'right',
@@ -47,6 +48,7 @@
                         animateFill: true,
                         animation: 'chapter-menu'
                     }"
+                    tabindex="0"
                     v-if="plugin"
                 >
                     <svg
@@ -87,7 +89,7 @@
                     <span class="flex-1 ml-4 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{
                         $t('chapters.return')
                     }}</span>
-                </a>
+                </span>
 
                 <router-link
                     :to="{ hash: '#intro' }"


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines/issues/560

### Changes
- Makes the items in the table of contents tabbable when in plugin mode (aka: when used in the editor's preview mode)

### Testing
This isn't going to be testable directly from the demo link unfortunately. If you'd like to test this PR, pull it locally and run [these steps](https://github.com/ramp4-pcar4/storylines/discussions/398) to test it with the editor.
