### PR TITLE
Normalize tag name for highcharts instance usage in plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.3.0",
+    "version": "3.4.0",
     "private": false,
     "license": "MIT",
     "type": "module",

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -7,7 +7,7 @@
             :aria-label="title"
             v-if="!loading"
         >
-            <charts :options="chartOptions"></charts>
+            <highchart :options="chartOptions"></highchart>
         </div>
     </div>
 </template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ const app = createApp(App);
 
 app.use(router)
     .use(i18n)
-    .use(HighchartsVue, { tagName: 'charts' })
+    .use(HighchartsVue, { tagName: 'highchart' })
     .use(VueTippy, {
         directive: 'tippy',
         component: 'tippy'


### PR DESCRIPTION
### Changes
- normalize highcharts tag name, required for when highcharts editor gets integrated as plugin 
- published new NPM version 3.4.0 with all the latest changes on main 

### Testing
Ensure Highcharts instances are still working here and in corresponding RESPECT PR: https://github.com/ramp4-pcar4/storylines-editor/pull/612
