### PR TITLE
remove empty div from ToC

### DIFF
--- a/src/components/panels/text-panel.vue
+++ b/src/components/panels/text-panel.vue
@@ -4,7 +4,7 @@
         :class="{ 'has-background': background }"
         :style="{ color: config.textColour ?? '#000' }"
     >
-        <component :is="config.titleTag || 'h2'" class="px-10 mb-0 chapter-title top-20">
+        <component v-if="config.title" :is="config.titleTag || 'h2'" class="px-10 mb-0 chapter-title top-20">
             {{ config.title }}
         </component>
 

--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -221,7 +221,6 @@
                     ></toc-item>
                 </li>
             </template>
-            <div class="h-10 flex-shrink-0"></div>
         </ul>
     </div>
 </template>


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/custom-projects/issues/280

### Changes
- Removes an empty `div` at the end of the table of contents that was causing an accessibility error.
- Only displays the header tag in a text panel if a title is provided.

### Testing
Steps:
1. Open the demo link.
2. Ensure that the table of contents is still working as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/569)
<!-- Reviewable:end -->
