### PR TITLE
import AudioPlayer and TextContent as async components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.4.0",
+    "version": "3.4.1",
     "private": false,
     "license": "MIT",
     "type": "module",

--- a/src/components/panels/helpers/text-content.vue
+++ b/src/components/panels/helpers/text-content.vue
@@ -8,8 +8,7 @@
  * To add support for a new inline component, simply import it here and add it to the `components` object.
  */
 
-import { compile, h } from 'vue';
-import AudioWidget from './audio-widget.vue';
+import { defineAsyncComponent, h } from 'vue';
 
 const props = defineProps({
     content: {
@@ -18,10 +17,12 @@ const props = defineProps({
     }
 });
 
+const AudioPlayer = defineAsyncComponent(() => import('./audio-widget.vue'));
+
 const render = () => {
     const r = {
         components: {
-            AudioPlayer: AudioWidget
+            AudioPlayer
         },
         template: `<div class="px-10 md-content object-contain">${props.content || ''}</div>`
     };

--- a/src/components/panels/text-panel.vue
+++ b/src/components/panels/text-panel.vue
@@ -13,13 +13,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { defineAsyncComponent, ref, onMounted } from 'vue';
 import type { PropType } from 'vue';
 import type { TextPanel } from '@storylines/definitions';
 
 import MarkdownIt from 'markdown-it';
 import Scrollama from './helpers/scrollama.vue';
-import TextContent from './helpers/text-content.vue';
+
+const TextContent = defineAsyncComponent(() => import('./helpers/text-content.vue'));
 
 const props = defineProps({
     config: {


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines-editor/issues/619

### Changes
- Imports AudioPlayer and TextContent as async components. Everything should still work the same for Storylines, but hopefully this fixes the issue with text not rendering within RESPECT.
- Bump Storylines version to 3.4.1.

### Testing
Steps:
1. Open demo link.
2. Ensure text and audio player is still working as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/570)
<!-- Reviewable:end -->
