### PR TITLE
Fix console errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
-    "version": "3.3.0",
+    "version": "3.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ramp-storylines_demo-scenarios-pcar",
-            "version": "3.3.0",
+            "version": "3.4.0",
             "license": "MIT",
             "dependencies": {
                 "@rollup/plugin-dsv": "^3.0.4",

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -225,7 +225,7 @@ const parseCSVFile = (data: CSVFile): void => {
             renderTo: 'dv-chart-container',
             type: dqvOptions?.type,
             ...(dqvOptions?.height &&
-                el.value.clientHeight >= dqvOptions.height && {
+                el.value?.clientHeight >= dqvOptions.height && {
                     height: dqvOptions.height
                 }),
             ...(dqvOptions?.width && el.value.clientWidth >= dqvOptions.width && { width: dqvOptions.width })

--- a/src/components/panels/helpers/point-of-interest-item.vue
+++ b/src/components/panels/helpers/point-of-interest-item.vue
@@ -74,7 +74,7 @@ onMounted(() => {
 
         isMobile.value = window.innerWidth <= 640;
         const clientHeight = window.innerHeight;
-        const poiHeight = poi.value.clientHeight;
+        const poiHeight = poi.value?.clientHeight;
         if (poiHeight > clientHeight * 0.6) {
             threshold.value = ((clientHeight * 0.6) / poiHeight) * 0.6;
         }
@@ -82,17 +82,16 @@ onMounted(() => {
         poiObserver = new IntersectionObserver(intersectionHandler, {
             threshold: threshold.value
         });
-
-        poiObserver.observe(poi.value);
+        poi.value && poiObserver.observe(poi.value as Element);
     });
-    resizeObserver.observe(poi.value);
+    poi.value && resizeObserver.observe(poi.value as Element);
 
     // Hook up the initial intersection observer.
     let poiObserver = new IntersectionObserver(intersectionHandler, {
         threshold: threshold.value
     });
 
-    poiObserver.observe(poi.value);
+    poi.value && poiObserver.observe(poi.value as Element);
 });
 
 const intersectionHandler = (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -111,7 +111,7 @@ onMounted((): void => {
         }
     }
 
-    observer.value?.observe(img.value as Element);
+    img.value && observer.value?.observe(img.value as Element);
 });
 </script>
 

--- a/src/components/panels/interactive-image-panel.vue
+++ b/src/components/panels/interactive-image-panel.vue
@@ -169,7 +169,7 @@ onMounted(() => {
         });
     }
 
-    observer.value?.observe(img.value as Element);
+    img.value && observer.value?.observe(img.value as Element);
 
     // Check for a switch from normal view to mobile view. Fixed text panel width will need to be adjusted.
     isMobile.value = window.innerWidth <= 640;

--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -95,7 +95,7 @@ onMounted(() => {
         { threshold: [0] }
     );
 
-    observer.observe(el.value);
+    el.value && observer.observe(el.value as Element);
 });
 
 const init = async () => {

--- a/src/components/panels/video-panel.vue
+++ b/src/components/panels/video-panel.vue
@@ -191,7 +191,7 @@ onMounted(() => {
     }
 
     if (vid.value) {
-        observer.value?.observe(vid.value as HTMLVideoElement);
+        vid.value && observer.value?.observe(vid.value as HTMLVideoElement);
     }
 });
 

--- a/src/components/story/slide.vue
+++ b/src/components/story/slide.vue
@@ -72,7 +72,7 @@ onMounted(() => {
         observer.value?.disconnect();
 
         const clientHeight = window.innerHeight;
-        const poiHeight = (slide.value as Element).clientHeight;
+        const poiHeight = (slide.value as Element)?.clientHeight;
         if (poiHeight > clientHeight * defaultThreshold) {
             scrollThreshold.value = ((clientHeight * defaultThreshold) / poiHeight) * defaultThreshold;
         }
@@ -89,9 +89,9 @@ onMounted(() => {
             }
         );
 
-        observer.value.observe(slide.value as Element);
+        slide.value && observer.value.observe(slide.value as Element);
     });
-    resizeObserver.observe(slide.value as Element);
+    slide.value && resizeObserver.observe(slide.value as Element);
 
     observer.value = new IntersectionObserver(
         ([slide]) => {
@@ -103,7 +103,7 @@ onMounted(() => {
         { rootMargin: '0px', threshold: scrollThreshold.value }
     );
 
-    observer.value?.observe(slide.value as Element);
+    slide.value && observer.value?.observe(slide.value as Element);
 
     // check if there is one text panel and one non-text panel in the slide and user did not specify a width in config
     if (panels.length == 2 && !panels[0]?.width && !panels[1]?.width) {


### PR DESCRIPTION
### Changes
- Fix console errors that occur upon attempting to access something that's `undefined`/`null`
  - Attempting to observe an `undefined`/`null` element
  - Attempting to access the `clientWidth` property of something that's `undefined`/`null`

### Testing
Steps:
1. Load in a product
2. Ensure that you do not get any errors for resize observers or `clientWidth`
3. Switch languages and ensure that you do not get any of the above errors
4. Try this out in the editor's preview as well
