### PR TITLE
Styling fixed for long horizontal ToC

### DIFF
--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -689,7 +689,7 @@
             ]
         }
     ],
-    "tocOrientation": "vertical",
+    "tocOrientation": "horizontal",
     "stylesheets": ["00000000-0000-0000-0000-000000000000/styles/main.css"],
     "contextLink": "https://www.canada.ca/en/environment-climate-change/services/national-pollutant-release-inventory/tools-resources-data/exploredata.html",
     "contextLabel": "Explore National Pollutant Release Inventory data",

--- a/src/components/story/horizontal-menu.vue
+++ b/src/components/story/horizontal-menu.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="h-navbar" class="navbar h-11 sticky">
+    <div id="h-navbar" class="navbar sticky">
         <ul>
             <li v-if="introExists && returnToTop">
                 <a
@@ -282,6 +282,7 @@ const handleFocus = (idx: number) => {
 
 .navbar > ul {
     display: flex;
+    row-gap: 5px;
     list-style-type: none;
     text-align: center;
     justify-content: center;
@@ -292,6 +293,7 @@ const handleFocus = (idx: number) => {
 }
 
 .navbar > ul > li {
+    background-color: white;
     float: left;
     width: 12%;
     border-radius: 8px;


### PR DESCRIPTION
### Related Item(s)
Issue #531 

### Changes
Extended the styling past the first row for Horizontal ToC, including white button background, gray background, slightly increased distance between rows

### Testing
Steps:
1. Load a storylines with many chapters with horizontal ToC
2. Notice the ToC has consistent styling even past the first row and there are no overlaps
