### PR TITLE
Add breaks: true to MD parser and update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.4.1",
+    "version": "3.5.1",
     "private": false,
     "license": "MIT",
     "type": "module",

--- a/src/components/panels/text-panel.vue
+++ b/src/components/panels/text-panel.vue
@@ -32,7 +32,7 @@ const props = defineProps({
     }
 });
 
-const md = new MarkdownIt({ html: true });
+const md = new MarkdownIt({ html: true, breaks: true });
 const mdContent = ref('');
 
 onMounted((): void => {


### PR DESCRIPTION
### Related Item(s)
PR [#633](https://github.com/ramp4-pcar4/storylines-editor/pull/633#issue-3119024194)

### Changes
- Added `breaks: true` to MD parser to ensure that whitespace formatting in the preview matches the text layout in the editor. 
- Updated version to 3.5.1

### Testing
Steps:
1. Test PR [#633](https://github.com/ramp4-pcar4/storylines-editor/pull/633#issue-3119024194) and ensure text pane preview and storyline preview have the same format. 
