### PR TITLE
Set minItems for slideshow to 0

### DIFF
--- a/StorylinesSchema.json
+++ b/StorylinesSchema.json
@@ -790,7 +790,7 @@
                             }
                         ]
                     },
-                    "minItems": 1
+                    "minItems": 0
                 },
                 "loop": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "private": false,
     "license": "MIT",
     "type": "module",


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines-editor/issues/681

### Changes
- Within the schema, set `minItems` to 0 for slideshow panels to prevent schema errors upon creating a new slideshow panel
- Update version number (have already published to npm)

### Testing
Test the following PR: https://github.com/ramp4-pcar4/storylines-editor/pull/687
