### PR TITLE
Remove the minimum height of the story

### DIFF
--- a/src/components/story/background-image.vue
+++ b/src/components/story/background-image.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="sticky z-10 grid-background overflow-hidden" style="top: 60px; height: 100vh">
+    <div class="sticky z-10 grid-background overflow-hidden" style="top: 60px;">
         <!-- Vue3 transition for switching between a slide with no background a slide with a background. -->
         <Transition name="fade" mode="out-in">
             <div v-if="state.newImage !== 'none'" class="w-full h-full">


### PR DESCRIPTION
### Related Item(s)
Issue #590 

### Changes
- Removed the requirement for the story to take up 100vh -> no more empty space at the bottom when slides don't take up enough space

### Testing
Steps:
1. Load a product with few and small slides
2. The container only extends as far as the slides go
