### PR TITLE
Preview footer now should be perfect height

### DIFF
--- a/src/components/panels/helpers/scrollama.vue
+++ b/src/components/panels/helpers/scrollama.vue
@@ -7,6 +7,7 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref, watchEffect } from 'vue';
 import scrollama from 'scrollama';
+import { offset } from 'highcharts';
 
 const emit = defineEmits(['step-progress', 'step-enter', 'step-exit']);
 
@@ -40,8 +41,8 @@ function getDynamicOffset(): number {
     const navbar = document.getElementById('h-navbar');
     if (!navbar) return 0.2;
     const navbarHeight = navbar.offsetHeight;
-    const offsetRatio = navbarHeight / window.innerHeight;
-    return offsetRatio + 0.07;
+    const offsetRatio = (navbarHeight + 64) / window.innerHeight;
+    return offsetRatio;
 }
 
 function setup() {

--- a/src/components/story/background-image.vue
+++ b/src/components/story/background-image.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="sticky z-10 grid-background overflow-hidden" style="top: 60px; height: 100vh">
+    <div class="sticky z-10 grid-background overflow-hidden" style="top: 60px;">
         <!-- Vue3 transition for switching between a slide with no background a slide with a background. -->
         <Transition name="fade" mode="out-in">
             <div v-if="state.newImage !== 'none'" class="w-full h-full">


### PR DESCRIPTION
### Related Item(s)
Issue #592 

### Changes
- Using more accurate actual measurements of the page to determine footerpadding height

### Notes
- When there is only one slide and it is very small, seems that the footerpadding is just a tad too large, not sure what is causing this but I suspect something about the loading order of elements on the page

- When you load or reload the page on any zoom size, it works as intended, but if you zoom in while you're on the page sometimes the last chapter ToC button does not highlight correctly — not sure if I should just add some extra footerpadding space for this or if it is fine

- I will revert the 00000000-0000-0000-0000-000000000000_en product file when this PR is approved

### Testing
Steps:
1. Use different slide heights as the last slide 
2. See footer change height based on last slide

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/593)
<!-- Reviewable:end -->
