### PR TITLE
Fix RESPECT local preview build issue for missing video ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-storylines_demo-scenarios-pcar",
     "description": "A user-configurable story product featuring interactive maps, charts and dynamic multimedia content alongside text.",
-    "version": "3.5.5",
+    "version": "3.5.7",
     "private": false,
     "license": "MIT",
     "type": "module",

--- a/src/components/panels/video-panel.vue
+++ b/src/components/panels/video-panel.vue
@@ -9,6 +9,7 @@
         <template v-if="config.videoType === 'YouTube'">
             <iframe
                 class="media-player"
+                ref="ytVid"
                 :title="config.title"
                 :src="config.src"
                 :height="config.height ? `${config.height}` : '500px'"
@@ -123,6 +124,7 @@ const rawTranscript = ref('');
 const transcriptContent = ref('');
 
 const vid = ref<HTMLVideoElement>();
+const ytVid = ref<HTMLIFrameElement>();
 const observer = ref<IntersectionObserver | undefined>(undefined);
 const loaded = ref<Boolean>(false);
 
@@ -188,15 +190,16 @@ onMounted(() => {
                 });
             });
         }
-    }
-
-    if (!vid.value) {
+    }   
+    
+    const vidElement = vid.value ?? ytVid.value;
+    if (!vidElement) {
         // TODO remove this if no one ever sees this message by Dec 2025
         console.error('video-panel: Bound element did not exist after mount');
         console.trace();
     }
 
-    observer.value?.observe(vid.value as HTMLVideoElement);
+    observer.value?.observe(vidElement as HTMLVideoElement | HTMLIFrameElement);
 });
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines-editor/issues/719, https://github.com/ramp4-pcar4/storylines-editor/pull/711

### Changes
- fixes issue of RESPECT preview breaking for saved products with a YT video panel (e.g. 0000 product) resulting in no existing video ref
- published version 3.5.7 to NPM

### Testing
Test loading 0000 product in demo page in https://github.com/ramp4-pcar4/storylines-editor/pull/711, however is local issue so will need to confirm after merge

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines/598)
<!-- Reviewable:end -->
