### PR TITLE
dynamic text section should now properly display line breaks

### DIFF
--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -687,6 +687,34 @@
                     "type": "image"
                 }
             ]
+        },
+        {
+            "title": "",
+            "panel": [
+                {
+                    "type": "dynamic",
+                    "title": "",
+                    "content": "e\ne\ne",
+                    "children": []
+                }
+            ],
+            "includeInToc": true
+        },
+        {
+            "title": "",
+            "panel": [
+                {
+                    "type": "text",
+                    "title": "",
+                    "content": "e\ne\ne"
+                },
+                {
+                    "type": "text",
+                    "title": "",
+                    "content": ""
+                }
+            ],
+            "includeInToc": true
         }
     ],
     "tocOrientation": "vertical",

--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -100,7 +100,7 @@ const activeConfig = ref<BasePanel>(defaultPanel.panel);
 const activeIdx = ref(defaultPanel.id);
 const isMobile = ref(false);
 
-const md = new MarkdownIt({ html: true });
+const md = new MarkdownIt({ html: true, breaks: true });
 
 const key = getCurrentInstance()?.vnode.key as string;
 


### PR DESCRIPTION
### Related Item(s)
Storylines editor [Issue #707](https://github.com/ramp4-pcar4/storylines-editor/issues/707)

### Changes
- For dynamic panels, \n now properly renders as a line break in the preview

### Notes
- I will revert the product file when approved

### Testing
Steps:
1. The dynamic panel text section preview should match the actual preview
