### PR TITLE
Add multimediaVideo to multimediaSlideshow item types

### DIFF
--- a/StorylinesSchema.json
+++ b/StorylinesSchema.json
@@ -790,6 +790,9 @@
                             },
                             {
                                 "$ref": "#/$defs/dqvchartPanel"
+                            },
+                            {
+                                "$ref": "#/$defs/multimediaVideo"
                             }
                         ]
                     },


### PR DESCRIPTION
### Related Item(s)
RESPECT issue: [#738](https://github.com/ramp4-pcar4/storylines-editor/issues/738)

### Changes
- Added support for `multimediaVideo ` in `multimediaSlideshow` items 

### Testing
Steps:
1. Build as plugin for RESPECT
2. Create a slideshow panel and add a video item type
3. Upload a video
4. Go to `Advanced` editor and there should be no schema error
